### PR TITLE
Changed tile layer to use new Mapbox layer

### DIFF
--- a/map.html
+++ b/map.html
@@ -32,7 +32,7 @@
             
             function createMap(){
                 map = L.map('mapid').setView([getUrlVars()["lat"], getUrlVars()["lon"] ], 13);
-                 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                 L.tileLayer('https://api.mapbox.com/styles/v1/nealf/cj4a7oll139od2spe6ckgufjq/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoibmVhbGYiLCJhIjoiNmM4MGQ3M2UzNmVlMTY0OWNmZDhiZjk0YWZlYzQ4OTYifQ.VEiV66Tl7sjD5n-bDLjbhw', {
                     attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
                 }).addTo(map);
             }


### PR DESCRIPTION
Using a new tile layer I created with Mapbox Studio. Cleaner than the default OpenStreetMaps theme, but we are limited to a certain number of views per month, so we may need to revisit at some point to find a longer term solution.